### PR TITLE
Add a build user for the jenkins build

### DIFF
--- a/eclipse-test/1.0/Dockerfile
+++ b/eclipse-test/1.0/Dockerfile
@@ -8,5 +8,8 @@ USER root
 COPY docker-entrypoint.sh /opt/docker-entrypoint.sh
 RUN chmod +x /opt/docker-entrypoint.sh
 
+# add an user with 1000 for the build in jenkins
+RUN addgroup --gid 1000 build && adduser --uid 1000 --gid 1000 --disabled-password --gecos "" build
+
 USER seluser
 ENTRYPOINT ["/opt/docker-entrypoint.sh"]

--- a/rcptt/1.1/Dockerfile
+++ b/rcptt/1.1/Dockerfile
@@ -9,5 +9,8 @@ USER root
 COPY docker-entrypoint.sh /opt/docker-entrypoint.sh
 RUN chmod +x /opt/docker-entrypoint.sh
 
+# add an user with 1000 for the build in jenkins
+RUN addgroup --gid 1000 build && adduser --uid 1000 --gid 1000 --disabled-password --gecos "" build
+
 USER seluser
 ENTRYPOINT ["/opt/docker-entrypoint.sh"]

--- a/web/1.0/Dockerfile
+++ b/web/1.0/Dockerfile
@@ -6,5 +6,8 @@ USER root
 COPY docker-entrypoint.sh /opt/docker-entrypoint.sh
 RUN chmod +x /opt/docker-entrypoint.sh
 
+# add an user with 1000 for the build in jenkins
+RUN addgroup --gid 1000 build && adduser --uid 1000 --gid 1000 --disabled-password --gecos "" build
+
 USER seluser
 ENTRYPOINT ["/opt/docker-entrypoint.sh"]


### PR DESCRIPTION
Seems that the base image does not add anymore the user 'seluser' as user with id 1000.

we did this hack already for all other maven containers because of tycho.