### PR TITLE
XIVY-9169 conf.py - output svg, use common font families

### DIFF
--- a/read-the-docs/2/Dockerfile
+++ b/read-the-docs/2/Dockerfile
@@ -5,11 +5,6 @@ ADD requirements.txt requirements.txt
 RUN apk add --update --no-cache make && \
     apk add --update --no-cache graphviz font-noto && \    
     rm -rf /var/cache/apk/* && \
-    # only keep the font we need
-    cp /usr/share/fonts/noto/NotoSans-Regular.ttf /tmp/NotoSans-Regular.ttf && \
-    rm -rf /usr/share/fonts/noto/* && \
-    cp /tmp/NotoSans-Regular.ttf /usr/share/fonts/noto/NotoSans-Regular.ttf && \
-    rm /tmp/NotoSans-Regular.ttf && \
     # pyhton dependencies
     pip3 install -r requirements.txt
 

--- a/read-the-docs/2/Dockerfile
+++ b/read-the-docs/2/Dockerfile
@@ -3,7 +3,7 @@ FROM python:alpine3.15
 ADD requirements.txt requirements.txt
 
 RUN apk add --update --no-cache make && \
-    apk add --update --no-cache graphviz font-noto && \    
+    apk add --update --no-cache graphviz && \    
     rm -rf /var/cache/apk/* && \
     # pyhton dependencies
     pip3 install -r requirements.txt

--- a/read-the-docs/2/conf.py
+++ b/read-the-docs/2/conf.py
@@ -70,11 +70,11 @@ pygments_style = 'tango'
 add_function_parentheses = True
 
 # graphviz
-graphviz_output_format = 'png'
+graphviz_output_format = 'svg'
 graphviz_dot_args = [
   # node
   '-Nfontsize=15',
-  '-Nfontname=NotoSans',
+  '-Nfontname=Roboto,Helvetica Neue,Arial,sans-serif',
   '-Nfontcolor=#FFFFFF',
   '-Ncolor=#007095',
   '-Nshape=box',
@@ -84,7 +84,7 @@ graphviz_dot_args = [
   '-Nwidth=2',
   # edge
   '-Efontsize=15',
-  '-Efontname=NotoSans'
+  '-Efontname=Roboto,Helvetica Neue,Arial,sans-serif'
 ]
 
 


### PR DESCRIPTION
As discussed. Tested locally that these changes in conf.py work for SVG graphics generation.
Separate pull request for the actual graphics updates (labels placing, etc.)