### PR TITLE
Fix building oracle docker images by using legacy build mode

### DIFF
--- a/oracle/Jenkinsfile
+++ b/oracle/Jenkinsfile
@@ -9,6 +9,10 @@ pipeline {
     cron '@midnight'
   }
 
+  environment {
+    DOCKER_BUILDKIT='0'
+  }
+
   stages {
     stage('build') {
       steps {


### PR DESCRIPTION
In the [new Docker version](https://docs.docker.com/engine/release-notes/23.0/) the build is using `Buildx` and `BuildKit` as the defautl builder on linux, which causes problems for us.
By setting this flag we go back to the default builder that was used in `docker 20.x`