### PR TITLE
XIVY-16322 allow to configure gettext_compact via env

### DIFF
--- a/read-the-docs/2/conf.py
+++ b/read-the-docs/2/conf.py
@@ -60,13 +60,22 @@ def parse_project_name_from_pom():
     return name
 
 def localeDir():
-    # 1. get version from environment variable
+    # 1. get from environment variable
     import os
     if "LOCALEDIR" in os.environ:
       return os.environ['LOCALEDIR']
 
     # 2. fallback best practice
     return 'locales/'
+
+def gettextCompact():
+    # 1. get from environment variable
+    import os
+    if "GETTEXT_COMPACT" in os.environ:
+      return os.environ['GETTEXT_COMPACT']
+
+    # 2. fallback best practice
+    return True
 
 # project
 project = parse_project_name_from_pom()
@@ -140,7 +149,7 @@ html_favicon = '/doc-build/images/favicon.png'
 
 # locales
 locale_dirs = [localeDir()]
-gettext_compact = True
+gettext_compact = gettextCompact()
 
 # base urls
 # https://stackoverflow.com/questions/1227037/substitutions-inside-links-in-rest-sphinx


### PR DESCRIPTION
allows me to generate just one bulk-file for all axonivy/doc contents: works by passing the name of the "bulk" text domain

.e.g
`docker run -v .:/doc -u $(id -u) rtd make gettext BASEDIR=/doc GETTEXT_COMPACT=doc`

creates:
```
❯ ls -la build/gettext
total 1256
drwxr-xr-x  5 rew root    4096 Apr  8 11:31 .
drwxr-xr-x  5 rew root    4096 Apr  8 11:31 ..
-rw-r--r--  1 rew root 1262991 Apr  8 11:31 doc.pot
drwxr-xr-x 10 rew root    4096 Apr  8 11:31 .doctrees
drwxr-xr-x  2 rew root    4096 Apr  8 11:31 _sphinx_design_static
drwxr-xr-x  2 rew root    4096 Apr  8 11:31 _static

```